### PR TITLE
feat: add internationalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "i18next": "^23.11.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-i18next": "^15.4.0",
     "react-router-dom": "^7.6.3"
   },
   "devDependencies": {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,11 +1,13 @@
 // src/components/Navbar.jsx
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import '../styles/navbar.css';
 
 function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
+  const { t } = useTranslation();
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
@@ -18,7 +20,7 @@ function Navbar() {
   return (
     <nav className="navbar">
       <div className="navbar-logo">
-      <Link to="/" onClick={closeMenu} className="signature">Sebastian Carrera</Link>
+        <Link to="/" onClick={closeMenu} className="signature">Sebastian Carrera</Link>
       </div>
       <div className={`navbar-toggle ${isOpen ? 'open' : ''}`} onClick={toggleMenu}>
         <span></span>
@@ -28,17 +30,17 @@ function Navbar() {
       <ul className={`navbar-links ${isOpen ? 'active' : ''}`}>
         <li>
           <Link to="/proyectos" onClick={closeMenu} className={location.pathname === '/proyectos' ? 'active' : ''}>
-            Proyectos
+            {t('nav.projects')}
           </Link>
         </li>
         <li>
           <Link to="/habilidades" onClick={closeMenu} className={location.pathname === '/habilidades' ? 'active' : ''}>
-            Habilidades
+            {t('nav.skills')}
           </Link>
         </li>
         <li>
           <Link to="/contacto" onClick={closeMenu} className={location.pathname === '/contacto' ? 'active' : ''}>
-            Contacto
+            {t('nav.contact')}
           </Link>
         </li>
       </ul>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,21 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import es from './locales/es/translation.json';
+import en from './locales/en/translation.json';
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      es: { translation: es },
+      en: { translation: en },
+    },
+    lng: 'es',
+    fallbackLng: 'es',
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,99 @@
+{
+  "nav": {
+    "projects": "Projects",
+    "skills": "Skills",
+    "contact": "Contact"
+  },
+  "home": {
+    "name": "Juan Sebastián Carrera Moya",
+    "subtitle": "Frontend Web Designer and Developer",
+    "description": "I transform ideas into impactful and functional digital experiences.",
+    "viewProjects": "See projects"
+  },
+  "projects": {
+    "title": "Featured projects",
+    "viewProject": "View project",
+    "viewVideo": "Watch video",
+    "items": {
+      "1": {
+        "title": "Cybersecurity Landing",
+        "description": "Design and development of a web landing for an internal cybersecurity campaign for Porvenir employees."
+      },
+      "2": {
+        "title": "Mundo Colmena",
+        "description": "Interactive educational game landing developed with React and CSS animations. The purpose of the game was for participants to search in different places for QR codes that directed them to specific sections of the landing to perform various event-related challenges and communicate dynamically and interactively."
+      },
+      "3": {
+        "title": "Colmena Route Game",
+        "description": "Web application to record and visualize personal goals."
+      },
+      "4": {
+        "title": "UKCOL Wildlife Game",
+        "description": "Interactive game developed for touch screens that aims to teach in a friendly way about the diversity of the Colombian ecosystem."
+      },
+      "5": {
+        "title": "Pacman Anti-Fraud Game",
+        "description": "Educational interactive game developed with React and CSS animations."
+      },
+      "6": {
+        "title": "Goals App",
+        "description": "Web application to register and view personal goals."
+      },
+      "7": {
+        "title": "Personal Portfolio",
+        "description": "Design and development of my website as a front-end designer and developer."
+      },
+      "8": {
+        "title": "Pacman Anti-Fraud Game",
+        "description": "Educational interactive game developed with React and CSS animations."
+      },
+      "9": {
+        "title": "Goals App",
+        "description": "Web application to register and view personal goals."
+      }
+    }
+  },
+  "skills": {
+    "title": "Professional Skills",
+    "intro": "As a front-end web designer and developer, I combine creativity and technical precision to build impactful digital experiences.",
+    "categories": {
+      "tech": {
+        "title": "Languages & Technologies",
+        "items": ["HTML5", "CSS3", "JavaScript", "React", "WordPress"]
+      },
+      "design": {
+        "title": "Design & UI/UX",
+        "items": ["Figma", "Sketch", "Adobe XD", "Photoshop", "Illustrator", "After Effects"]
+      },
+      "frontend": {
+        "title": "Front-End Development",
+        "items": ["Reusable components", "Responsive design", "Performance optimization", "Accessibility (A11y)"]
+      },
+      "video": {
+        "title": "Audiovisual Production",
+        "items": ["Premiere Pro", "After Effects", "Audiovisual production", "Motion Graphics"]
+      },
+      "tools": {
+        "title": "Tools & Methodologies",
+        "items": ["Git", "SCRUM", "Basic technical SEO", "Deployment with Vite"]
+      },
+      "soft": {
+        "title": "Soft Skills",
+        "items": ["Project leadership", "Effective communication", "Creative thinking", "Time management"]
+      }
+    }
+  },
+  "contact": {
+    "title": "Contact",
+    "description": "Do you have a project in mind or just want to say hi? Write me!",
+    "form": {
+      "name": "Your name",
+      "email": "Your email",
+      "message": "Your message...",
+      "send": "Send message"
+    }
+  },
+  "common": {
+    "noVideoSupport": "Your browser does not support videos."
+  }
+}

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,0 +1,99 @@
+{
+  "nav": {
+    "projects": "Proyectos",
+    "skills": "Habilidades",
+    "contact": "Contacto"
+  },
+  "home": {
+    "name": "Juan Sebastián Carrera Moya",
+    "subtitle": "Diseñador y Desarrollador Web Frontend",
+    "description": "Transformo ideas en experiencias digitales impactantes y funcionales.",
+    "viewProjects": "Ver proyectos"
+  },
+  "projects": {
+    "title": "Proyectos destacados",
+    "viewProject": "Ver proyecto",
+    "viewVideo": "Ver video",
+    "items": {
+      "1": {
+        "title": "Landing Ciberseguridad",
+        "description": "Diseño y desarrollo de Landing Web para una campaña interna sobre Ciberseguridad a los empleados de Porvenir."
+      },
+      "2": {
+        "title": "Mundo Colmena",
+        "description": "Landing de juego educativo interactivo desarrollado con React y animaciones CSS, la finalidad del juego era que los participantes fueran buscando en diferentes lugares unos QR Codes donde los dirijian a secciones especificas de la landing para realizar distintos retos relacionados con el evento y cumplir con informar de una manera dinámica e interactiva."
+      },
+      "3": {
+        "title": "Colmena Route Game",
+        "description": "Aplicación web para registrar y visualizar propósitos personales."
+      },
+      "4": {
+        "title": "Juego UKCOL Vida Silvestre",
+        "description": "Juego interactivo desarrollado para pantallas touch, el cual busca enseñar de forma amigable sobre la diversidad del ecosistema Colombiano."
+      },
+      "5": {
+        "title": "Juego de Pacman Antifraude",
+        "description": "Juego educativo interactivo desarrollado con React y animaciones CSS."
+      },
+      "6": {
+        "title": "App de Propósitos",
+        "description": "Aplicación web para registrar y visualizar propósitos personales."
+      },
+      "7": {
+        "title": "Portafolio Personal",
+        "description": "Diseño y desarrollo de mi sitio web como diseñador y desarrollador front-end."
+      },
+      "8": {
+        "title": "Juego de Pacman Antifraude",
+        "description": "Juego educativo interactivo desarrollado con React y animaciones CSS."
+      },
+      "9": {
+        "title": "App de Propósitos",
+        "description": "Aplicación web para registrar y visualizar propósitos personales."
+      }
+    }
+  },
+  "skills": {
+    "title": "Habilidades Profesionales",
+    "intro": "Como diseñador y desarrollador web front-end, combino creatividad y precisión técnica para construir experiencias digitales impactantes.",
+    "categories": {
+      "tech": {
+        "title": "Lenguajes & Tecnologías",
+        "items": ["HTML5", "CSS3", "JavaScript", "React", "WordPress"]
+      },
+      "design": {
+        "title": "Diseño & UI/UX",
+        "items": ["Figma", "Sketch", "Adobe XD", "Photoshop", "Illustrator", "After Effects"]
+      },
+      "frontend": {
+        "title": "Desarrollo Front-End",
+        "items": ["Componentes reutilizables", "Diseño responsivo", "Optimización de rendimiento", "Accesibilidad (A11y)"]
+      },
+      "video": {
+        "title": "Producción Audiovisual",
+        "items": ["Premiere Pro", "After Effects", "Realización audiovisual", "Motion Graphics"]
+      },
+      "tools": {
+        "title": "Herramientas & Metodologías",
+        "items": ["Git", "SCRUM", "SEO técnico básico", "Deployment con Vite"]
+      },
+      "soft": {
+        "title": "Soft Skills",
+        "items": ["Liderazgo de proyectos", "Comunicación efectiva", "Pensamiento creativo", "Gestión del tiempo"]
+      }
+    }
+  },
+  "contact": {
+    "title": "Contacto",
+    "description": "¿Tienes un proyecto en mente o simplemente quieres saludar? ¡Escríbeme!",
+    "form": {
+      "name": "Tu nombre",
+      "email": "Tu correo electrónico",
+      "message": "Tu mensaje...",
+      "send": "Enviar mensaje"
+    }
+  },
+  "common": {
+    "noVideoSupport": "Tu navegador no soporta videos."
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+import i18n from './i18n.js';
 import App from './App.jsx';
 import './index.css';
 
@@ -21,11 +23,12 @@ function scrollReveal() {
 window.addEventListener('scroll', scrollReveal);
 window.addEventListener('DOMContentLoaded', scrollReveal);
 
-
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <I18nextProvider i18n={i18n}>
+        <App />
+      </I18nextProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import '../styles/contact.css';
 
 function Contact() {
+  const { t } = useTranslation();
+
   useEffect(() => {
     const revealElements = document.querySelectorAll('.reveal');
     const revealOnScroll = () => {
@@ -21,15 +24,15 @@ function Contact() {
   return (
     <section className="contact-section">
       <div className="contact-form">
-       <h2>Contacto</h2>
-       <p>¿Tienes un proyecto en mente o simplemente quieres saludar? ¡Escríbeme!</p>
-       <form>
-         <input type="text" placeholder="Tu nombre" />
-         <input type="email" placeholder="Tu correo electrónico" />
-         <textarea placeholder="Tu mensaje..." rows="4"></textarea>
-         <button type="submit">Enviar mensaje</button>
-       </form>
-     </div>
+        <h2>{t('contact.title')}</h2>
+        <p>{t('contact.description')}</p>
+        <form>
+          <input type="text" placeholder={t('contact.form.name')} />
+          <input type="email" placeholder={t('contact.form.email')} />
+          <textarea placeholder={t('contact.form.message')} rows="4"></textarea>
+          <button type="submit">{t('contact.form.send')}</button>
+        </form>
+      </div>
     </section>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,21 +1,22 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import '../styles/home.css';
-import videoBg from '../assets/video-fondo.mp4'; // Cambia el path según tu proyecto
+import videoBg from '../assets/video-fondo.mp4';
 
 function Home() {
+  const { t } = useTranslation();
   return (
     <section className="home">
       <video className="background-video" autoPlay muted loop playsInline>
         <source src={videoBg} type="video/mp4" />
-        Tu navegador no soporta videos.
+        {t('common.noVideoSupport')}
       </video>
       <div className="home-content">
-        <h1>Juan Sebastián Carrera Moya</h1>
-        <h2>Diseñador y Desarrollador Web Frontend</h2>
-        <p>Transformo ideas en experiencias digitales impactantes y funcionales.</p>
+        <h1>{t('home.name')}</h1>
+        <h2>{t('home.subtitle')}</h2>
+        <p>{t('home.description')}</p>
         <div className="buttons">
-          <a href="/proyectos" className="btn">Ver proyectos</a>
-          {/*<a href="/cv.pdf" className="btn" download>Descargar CV</a>*/}
+          <a href="/proyectos" className="btn">{t('home.viewProjects')}</a>
         </div>
       </div>
     </section>

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import '../styles/projects.css';
 import ciberImage from '../assets/projects/ciberseguridad.png';
 import ciberseguridadVideo from '../assets/videos/ciberseguridad.mp4';
@@ -9,80 +10,80 @@ import ColmenaRouteVideo from '../assets/videos/COLMENA-ROUTE-GAME.mp4';
 import UkcolTouchImage from '../assets/projects/ukcol-touch.png';
 import UkcolTouchVideo from '../assets/videos/ukcol-touch.mp4';
 
-const projects = [
-  {
-    id: 1,
-    title: "Landing Ciberseguridad",
-    description: "Diseño y desarrollo de Landing Web para una campaña interna sobre Ciberseguridad a los empleados de Porvenir.",
-    image: ciberImage,
-    video: ciberseguridadVideo,
-    link: "https://github.com/tuusuario/portafolio"
-  },
-  {
-    id: 2,
-    title: "Mundo Colmena",
-    description: "Landing de juego educativo interactivo desarrollado con React y animaciones CSS, la finalidad del juego era que los participantes fueran buscando en diferentes lugares unos QR Codes donde los dirijian a secciones especificas de la landing para realizar distintos retos relacionados con el evento y cumplir con informar de una manera dinámica e interactiva.",
-    image: mundoColmenaImage,
-    video: mundoColmenaVideo,
-    link: "https://github.com/tuusuario/pacman-antifraude"
-  },
-  {
-    id: 3,
-    title: "Colmena Route Game",
-    description: "Aplicación web para registrar y visualizar propósitos personales.",
-    image: ColmenaRouteImage,
-    video: ColmenaRouteVideo,
-    link: "https://github.com/tuusuario/app-propositos"
-  },
-  {
-    id: 4,
-    title: "Juego UKCOL Vida Silvestre",
-    description: "Juego interactivo desarrollado para pantallas touch, el cual busca enseñar de forma amigable sobre la diversidad del ecosistema Colombiano.",
-    image: UkcolTouchImage,
-    video: UkcolTouchVideo,
-    link: "https://github.com/tuusuario/portafolio"
-  },
-  {
-    id: 5,
-    title: "Juego de Pacman Antifraude",
-    description: "Juego educativo interactivo desarrollado con React y animaciones CSS.",
-    image: "/assets/projects/pacman.png",
-    link: "https://github.com/tuusuario/pacman-antifraude"
-  },
-  {
-    id: 6,
-    title: "App de Propósitos",
-    description: "Aplicación web para registrar y visualizar propósitos personales.",
-    image: "/assets/projects/propositos.png",
-    link: "https://github.com/tuusuario/app-propositos"
-  },
-  {
-    id: 7,
-    title: "Portafolio Personal",
-    description: "Diseño y desarrollo de mi sitio web como diseñador y desarrollador front-end.",
-    image: "/assets/projects/portafolio.png",
-    link: "https://github.com/tuusuario/portafolio"
-  },
-  {
-    id: 8,
-    title: "Juego de Pacman Antifraude",
-    description: "Juego educativo interactivo desarrollado con React y animaciones CSS.",
-    image: "/assets/projects/pacman.png",
-    link: "https://github.com/tuusuario/pacman-antifraude"
-  },
-  {
-    id: 9,
-    title: "App de Propósitos",
-    description: "Aplicación web para registrar y visualizar propósitos personales.",
-    image: "/assets/projects/propositos.png",
-    link: "https://github.com/tuusuario/app-propositos"
-  }
-];
-
 function Projects() {
+  const { t } = useTranslation();
   const [activeVideo, setActiveVideo] = useState(null);
-  const activeProject = projects.find(p => p.id === activeVideo);
-  // 👇 Scroll reveal
+
+  const projects = [
+    {
+      id: 1,
+      title: t('projects.items.1.title'),
+      description: t('projects.items.1.description'),
+      image: ciberImage,
+      video: ciberseguridadVideo,
+      link: 'https://github.com/tuusuario/portafolio'
+    },
+    {
+      id: 2,
+      title: t('projects.items.2.title'),
+      description: t('projects.items.2.description'),
+      image: mundoColmenaImage,
+      video: mundoColmenaVideo,
+      link: 'https://github.com/tuusuario/pacman-antifraude'
+    },
+    {
+      id: 3,
+      title: t('projects.items.3.title'),
+      description: t('projects.items.3.description'),
+      image: ColmenaRouteImage,
+      video: ColmenaRouteVideo,
+      link: 'https://github.com/tuusuario/app-propositos'
+    },
+    {
+      id: 4,
+      title: t('projects.items.4.title'),
+      description: t('projects.items.4.description'),
+      image: UkcolTouchImage,
+      video: UkcolTouchVideo,
+      link: 'https://github.com/tuusuario/portafolio'
+    },
+    {
+      id: 5,
+      title: t('projects.items.5.title'),
+      description: t('projects.items.5.description'),
+      image: '/assets/projects/pacman.png',
+      link: 'https://github.com/tuusuario/pacman-antifraude'
+    },
+    {
+      id: 6,
+      title: t('projects.items.6.title'),
+      description: t('projects.items.6.description'),
+      image: '/assets/projects/propositos.png',
+      link: 'https://github.com/tuusuario/app-propositos'
+    },
+    {
+      id: 7,
+      title: t('projects.items.7.title'),
+      description: t('projects.items.7.description'),
+      image: '/assets/projects/portafolio.png',
+      link: 'https://github.com/tuusuario/portafolio'
+    },
+    {
+      id: 8,
+      title: t('projects.items.8.title'),
+      description: t('projects.items.8.description'),
+      image: '/assets/projects/pacman.png',
+      link: 'https://github.com/tuusuario/pacman-antifraude'
+    },
+    {
+      id: 9,
+      title: t('projects.items.9.title'),
+      description: t('projects.items.9.description'),
+      image: '/assets/projects/propositos.png',
+      link: 'https://github.com/tuusuario/app-propositos'
+    }
+  ];
+
   useEffect(() => {
     const revealElements = document.querySelectorAll('.reveal');
 
@@ -105,10 +106,11 @@ function Projects() {
 
   const openModal = (id) => setActiveVideo(id);
   const closeModal = () => setActiveVideo(null);
+  const activeProject = projects.find(p => p.id === activeVideo);
 
   return (
     <section className="projects-container">
-      <h2 className="reveal">Proyectos destacados</h2>
+      <h2 className="reveal">{t('projects.title')}</h2>
       <div className="projects-grid reveal">
         {projects.map((project) => (
           <div className="project-card" key={project.id}>
@@ -116,25 +118,24 @@ function Projects() {
             <h3>{project.title}</h3>
             <p>{project.description}</p>
             <a href={project.link} target="_blank" rel="noopener noreferrer">
-              Ver proyecto
+              {t('projects.viewProject')}
             </a>
             {project.video && (
               <button className="video-btn" onClick={() => openModal(project.id)}>
-                Ver video
+                {t('projects.viewVideo')}
               </button>
             )}
           </div>
         ))}
       </div>
 
-      {/* Modal */}
       {activeProject && (
         <div className="modal-overlay" onClick={closeModal}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <button className="modal-close" onClick={closeModal}>✕</button>
             <video controls autoPlay className="modal-video">
               <source src={activeProject.video} type="video/mp4" />
-              Tu navegador no soporta el video.
+              {t('common.noVideoSupport')}
             </video>
           </div>
         </div>

--- a/src/pages/Skills.jsx
+++ b/src/pages/Skills.jsx
@@ -1,27 +1,20 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import '../styles/skills.css';
 
-const skills = [
-  { category: 'Lenguajes & Tecnologías', items: ['HTML5', 'CSS3', 'JavaScript', 'React', 'WordPress'] },
-  { category: 'Diseño & UI/UX', items: ['Figma', 'Sketch', 'Adobe XD', 'Photoshop', 'Illustrator', 'After Effects'] },
-  { category: 'Desarrollo Front-End', items: ['Componentes reutilizables', 'Diseño responsivo', 'Optimización de rendimiento', 'Accesibilidad (A11y)'] },
-  { category: 'Producción Audiovisual', items: ['Premiere Pro', 'After Effects', 'Realización audiovisual', 'Motion Graphics'] },
-  { category: 'Herramientas & Metodologías', items: ['Git', 'SCRUM', 'SEO técnico básico', 'Deployment con Vite'] },
-  { category: 'Soft Skills', items: ['Liderazgo de proyectos', 'Comunicación efectiva', 'Pensamiento creativo', 'Gestión del tiempo'] },
-];
-
 function Skills() {
+  const { t } = useTranslation();
+  const categories = t('skills.categories', { returnObjects: true });
+
   return (
     <section className="skills-container">
       <div className="skills-overlay">
-        <h2>Habilidades Profesionales</h2>
-        <p className="skills-intro">
-          Como diseñador y desarrollador web front-end, combino creatividad y precisión técnica para construir experiencias digitales impactantes.
-        </p>
+        <h2>{t('skills.title')}</h2>
+        <p className="skills-intro">{t('skills.intro')}</p>
         <div className="skills-grid">
-          {skills.map((skill, index) => (
+          {Object.values(categories).map((skill, index) => (
             <div className="skill-card reveal" key={index}>
-              <h3>{skill.category}</h3>
+              <h3>{skill.title}</h3>
               <ul>
                 {skill.items.map((item, idx) => (
                   <li key={idx}>{item}</li>


### PR DESCRIPTION
## Summary
- add i18next setup with Spanish defaults and English fallback
- provide translation resources for navigation, pages and project data
- replace hardcoded strings with `useTranslation` hooks across components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a505534fb88320b9c27634efc9b27a