### PR TITLE
feat: add language selector to navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,10 +1,12 @@
 // src/components/Navbar.jsx
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import i18n from 'i18next';
 import '../styles/navbar.css';
 
 function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
+  const [language, setLanguage] = useState(localStorage.getItem('language') || 'es');
   const location = useLocation();
 
   const toggleMenu = () => {
@@ -14,6 +16,17 @@ function Navbar() {
   const closeMenu = () => {
     setIsOpen(false);
   };
+
+  const handleLanguageChange = (lng) => {
+    setLanguage(lng);
+    i18n.changeLanguage(lng);
+    localStorage.setItem('language', lng);
+    closeMenu();
+  };
+
+  useEffect(() => {
+    i18n.changeLanguage(language);
+  }, [language]);
 
   return (
     <nav className="navbar">
@@ -40,6 +53,12 @@ function Navbar() {
           <Link to="/contacto" onClick={closeMenu} className={location.pathname === '/contacto' ? 'active' : ''}>
             Contacto
           </Link>
+        </li>
+        <li className="language-selector">
+          <select value={language} onChange={(e) => handleLanguageChange(e.target.value)}>
+            <option value="es">ES</option>
+            <option value="en">EN</option>
+          </select>
         </li>
       </ul>
     </nav>

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -63,6 +63,20 @@
   border-bottom: 2px solid #00ffff;
 }
 
+.language-selector select {
+  background: transparent;
+  border: 1px solid #ffffff;
+  color: #ffffff;
+  font-family: 'Roboto', sans-serif;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-right: 25px;
+}
+
+.language-selector option {
+  color: #000000;
+}
+
 /* Hamburguesa para móviles */
 .navbar-toggle {
   display: none;


### PR DESCRIPTION
## Summary
- allow users to switch between Spanish and English in the navbar
- remember chosen language using localStorage
- add styles for language selector to blend with existing design

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a50f8261b8832093e8183f73908dc1