### PR TITLE
feat: add language-prefixed routes with redirects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 // src/App.jsx
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Navbar from './components/Navbar';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Layout from './components/Layout';
 import Home from './pages/Home';
 import Projects from './pages/Projects';
 import Skills from './pages/Skills';
@@ -9,15 +9,24 @@ import Contact from './pages/Contact';
 
 function App() {
   return (
-    <>
-      <Navbar />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/proyectos" element={<Projects />} />
-        <Route path="/habilidades" element={<Skills />} />
-        <Route path="/contacto" element={<Contact />} />
+        <Route path="/:lang(en|es)" element={<Layout />}>
+          <Route index element={<Home />} />
+          <Route path="proyectos" element={<Projects />} />
+          <Route path="habilidades" element={<Skills />} />
+          <Route path="contacto" element={<Contact />} />
+          <Route path="projects" element={<Projects />} />
+          <Route path="skills" element={<Skills />} />
+          <Route path="contact" element={<Contact />} />
+        </Route>
+        <Route path="/" element={<Navigate to="/es" replace />} />
+        <Route path="/proyectos" element={<Navigate to="/es/proyectos" replace />} />
+        <Route path="/habilidades" element={<Navigate to="/es/habilidades" replace />} />
+        <Route path="/contacto" element={<Navigate to="/es/contacto" replace />} />
+        <Route path="/projects" element={<Navigate to="/en/projects" replace />} />
+        <Route path="/skills" element={<Navigate to="/en/skills" replace />} />
+        <Route path="/contact" element={<Navigate to="/en/contact" replace />} />
       </Routes>
-    </>
   );
 }
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import Navbar from './Navbar';
+
+function Layout() {
+  return (
+    <>
+      <Navbar />
+      <Outlet />
+    </>
+  );
+}
+
+export default Layout;

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,11 +1,22 @@
 // src/components/Navbar.jsx
 import React, { useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router-dom';
 import '../styles/navbar.css';
 
 function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
   const location = useLocation();
+  const { lang = 'es' } = useParams();
+
+  const paths = {
+    es: { projects: 'proyectos', skills: 'habilidades', contact: 'contacto' },
+    en: { projects: 'projects', skills: 'skills', contact: 'contact' }
+  };
+
+  const labels = {
+    es: { projects: 'Proyectos', skills: 'Habilidades', contact: 'Contacto' },
+    en: { projects: 'Projects', skills: 'Skills', contact: 'Contact' }
+  };
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
@@ -15,10 +26,14 @@ function Navbar() {
     setIsOpen(false);
   };
 
+  const currentPath = location.pathname;
+  const langPaths = paths[lang] || paths.es;
+  const langLabels = labels[lang] || labels.es;
+
   return (
     <nav className="navbar">
       <div className="navbar-logo">
-      <Link to="/" onClick={closeMenu} className="signature">Sebastian Carrera</Link>
+        <Link to={`/${lang}`} onClick={closeMenu} className="signature">Sebastian Carrera</Link>
       </div>
       <div className={`navbar-toggle ${isOpen ? 'open' : ''}`} onClick={toggleMenu}>
         <span></span>
@@ -27,18 +42,30 @@ function Navbar() {
       </div>
       <ul className={`navbar-links ${isOpen ? 'active' : ''}`}>
         <li>
-          <Link to="/proyectos" onClick={closeMenu} className={location.pathname === '/proyectos' ? 'active' : ''}>
-            Proyectos
+          <Link
+            to={`/${lang}/${langPaths.projects}`}
+            onClick={closeMenu}
+            className={currentPath.endsWith(`/${langPaths.projects}`) ? 'active' : ''}
+          >
+            {langLabels.projects}
           </Link>
         </li>
         <li>
-          <Link to="/habilidades" onClick={closeMenu} className={location.pathname === '/habilidades' ? 'active' : ''}>
-            Habilidades
+          <Link
+            to={`/${lang}/${langPaths.skills}`}
+            onClick={closeMenu}
+            className={currentPath.endsWith(`/${langPaths.skills}`) ? 'active' : ''}
+          >
+            {langLabels.skills}
           </Link>
         </li>
         <li>
-          <Link to="/contacto" onClick={closeMenu} className={location.pathname === '/contacto' ? 'active' : ''}>
-            Contacto
+          <Link
+            to={`/${lang}/${langPaths.contact}`}
+            onClick={closeMenu}
+            className={currentPath.endsWith(`/${langPaths.contact}`) ? 'active' : ''}
+          >
+            {langLabels.contact}
           </Link>
         </li>
       </ul>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import { Link, useParams } from 'react-router-dom';
 import '../styles/home.css';
 import videoBg from '../assets/video-fondo.mp4'; // Cambia el path según tu proyecto
 
 function Home() {
+  const { lang = 'es' } = useParams();
+  const projectPath = lang === 'en' ? 'projects' : 'proyectos';
+  const buttonText = lang === 'en' ? 'View projects' : 'Ver proyectos';
+
   return (
     <section className="home">
       <video className="background-video" autoPlay muted loop playsInline>
@@ -14,7 +19,7 @@ function Home() {
         <h2>Diseñador y Desarrollador Web Frontend</h2>
         <p>Transformo ideas en experiencias digitales impactantes y funcionales.</p>
         <div className="buttons">
-          <a href="/proyectos" className="btn">Ver proyectos</a>
+          <Link to={`/${lang}/${projectPath}`} className="btn">{buttonText}</Link>
           {/*<a href="/cv.pdf" className="btn" download>Descargar CV</a>*/}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- allow optional `/:lang` segment with both English and Spanish route names
- update navigation and home link to respect current language
- redirect legacy URLs to language-prefixed paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a510b40ce8832096c0b1a7da73f9a5