### PR TITLE
feat: set default language to Spanish with selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,10 +1,12 @@
 // src/components/Navbar.jsx
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import '../styles/navbar.css';
+import { LanguageContext } from '../context/LanguageContext.jsx';
 
 function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
+  const { language, setLanguage } = useContext(LanguageContext);
   const location = useLocation();
 
   const toggleMenu = () => {
@@ -42,6 +44,10 @@ function Navbar() {
           </Link>
         </li>
       </ul>
+      <select className="lang-select" value={language} onChange={(e) => setLanguage(e.target.value)}>
+        <option value="es">ES</option>
+        <option value="en">EN</option>
+      </select>
     </nav>
   );
 }

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,19 @@
+// src/context/LanguageContext.jsx
+/* eslint-disable react-refresh/only-export-components */
+import React, { createContext, useState, useEffect } from 'react';
+
+export const LanguageContext = createContext();
+
+export function LanguageProvider({ children }) {
+  const [language, setLanguage] = useState('es');
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 import './index.css';
+import { LanguageProvider } from './context/LanguageContext.jsx';
 
 function scrollReveal() {
   const reveals = document.querySelectorAll('.reveal');
@@ -25,7 +26,9 @@ window.addEventListener('DOMContentLoaded', scrollReveal);
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <LanguageProvider>
+        <App />
+      </LanguageProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- default HTML language set to Spanish
- add context-driven language provider and navbar selector

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a511dd47488320bb11e20dbd4c4b19