### PR TITLE
Add bilingual support and restore app rendering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,8 +14,11 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/proyectos" element={<Projects />} />
+        <Route path="/projects" element={<Projects />} />
         <Route path="/habilidades" element={<Skills />} />
+        <Route path="/skills" element={<Skills />} />
         <Route path="/contacto" element={<Contact />} />
+        <Route path="/contact" element={<Contact />} />
       </Routes>
     </>
   );

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,14 +1,17 @@
 // src/components/Navbar.jsx
 
-import { Link, useLocation } from 'react-router-dom';
+import React, { useState, useContext } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import '../styles/navbar.css';
 import { LanguageContext } from '../context/LanguageContext.jsx';
 
 function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
-
   const location = useLocation();
+  const navigate = useNavigate();
   const { t } = useTranslation();
+  const { language, setLanguage } = useContext(LanguageContext);
 
   const toggleMenu = () => {
     setIsOpen(!isOpen);
@@ -20,14 +23,24 @@ function Navbar() {
 
   const handleLanguageChange = (lng) => {
     setLanguage(lng);
-    i18n.changeLanguage(lng);
-    localStorage.setItem('language', lng);
+    const pathMap = {
+      '/proyectos': '/projects',
+      '/projects': '/proyectos',
+      '/habilidades': '/skills',
+      '/skills': '/habilidades',
+      '/contacto': '/contact',
+      '/contact': '/contacto',
+    };
+    const newPath = pathMap[location.pathname] || '/';
+    navigate(newPath);
     closeMenu();
   };
 
-  useEffect(() => {
-    i18n.changeLanguage(language);
-  }, [language]);
+  const navLinks = {
+    projects: language === 'en' ? '/projects' : '/proyectos',
+    skills: language === 'en' ? '/skills' : '/habilidades',
+    contact: language === 'en' ? '/contact' : '/contacto',
+  };
 
   return (
     <nav className="navbar">
@@ -41,17 +54,17 @@ function Navbar() {
       </div>
       <ul className={`navbar-links ${isOpen ? 'active' : ''}`}>
         <li>
-          <Link to="/proyectos" onClick={closeMenu} className={location.pathname === '/proyectos' ? 'active' : ''}>
+          <Link to={navLinks.projects} onClick={closeMenu} className={location.pathname === navLinks.projects ? 'active' : ''}>
             {t('nav.projects')}
           </Link>
         </li>
         <li>
-          <Link to="/habilidades" onClick={closeMenu} className={location.pathname === '/habilidades' ? 'active' : ''}>
+          <Link to={navLinks.skills} onClick={closeMenu} className={location.pathname === navLinks.skills ? 'active' : ''}>
             {t('nav.skills')}
           </Link>
         </li>
         <li>
-          <Link to="/contacto" onClick={closeMenu} className={location.pathname === '/contacto' ? 'active' : ''}>
+          <Link to={navLinks.contact} onClick={closeMenu} className={location.pathname === navLinks.contact ? 'active' : ''}>
             {t('nav.contact')}
           </Link>
         </li>
@@ -62,10 +75,6 @@ function Navbar() {
           </select>
         </li>
       </ul>
-      <select className="lang-select" value={language} onChange={(e) => setLanguage(e.target.value)}>
-        <option value="es">ES</option>
-        <option value="en">EN</option>
-      </select>
     </nav>
   );
 }

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,14 +1,17 @@
 // src/context/LanguageContext.jsx
 /* eslint-disable react-refresh/only-export-components */
 import React, { createContext, useState, useEffect } from 'react';
+import i18n from '../i18n.js';
 
 export const LanguageContext = createContext();
 
 export function LanguageProvider({ children }) {
-  const [language, setLanguage] = useState('es');
+  const [language, setLanguage] = useState(() => localStorage.getItem('language') || 'es');
 
   useEffect(() => {
+    i18n.changeLanguage(language);
     document.documentElement.lang = language;
+    localStorage.setItem('language', language);
   }, [language]);
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,9 +24,14 @@ function scrollReveal() {
 window.addEventListener('scroll', scrollReveal);
 window.addEventListener('DOMContentLoaded', scrollReveal);
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <BrowserRouter>
-    </BrowserRouter>
-  </StrictMode>
-);
+  createRoot(document.getElementById('root')).render(
+    <StrictMode>
+      <I18nextProvider i18n={i18n}>
+        <LanguageProvider>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </LanguageProvider>
+      </I18nextProvider>
+    </StrictMode>
+  );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,10 +1,15 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import '../styles/home.css';
 import videoBg from '../assets/video-fondo.mp4';
+import { LanguageContext } from '../context/LanguageContext.jsx';
 
 function Home() {
   const { t } = useTranslation();
+  const { language } = useContext(LanguageContext);
+  const projectsPath = language === 'en' ? '/projects' : '/proyectos';
+
   return (
     <section className="home">
       <video className="background-video" autoPlay muted loop playsInline>
@@ -15,11 +20,11 @@ function Home() {
         <h1>{t('home.name')}</h1>
         <h2>{t('home.subtitle')}</h2>
         <p>{t('home.description')}</p>
-        <div className="buttons">
-          <a href="/proyectos" className="btn">{t('home.viewProjects')}</a>
+          <div className="buttons">
+            <Link to={projectsPath} className="btn">{t('home.viewProjects')}</Link>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- Wrap React app with i18next, language context, and router to render correctly
- Load and persist selected language while updating document `lang`
- Add dynamic navbar with language switcher and English routes
- Link Home page to language-specific Projects route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a501199d048320b1edb270df1eaaad